### PR TITLE
Add API first libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ Uploads a new version of a delivery to the system. This route will check if data
 
 ### GET /deliveries/:deliveryman/:date_from/:date_to
 
-Retrieves all deliveries registered in the system of a deliveryman by a period of time.
+Retrieves all deliveries registered in the system of a deliveryman by a period of time. As our database
+will be set to return 100 docs maximum by query, our API returns a bookmark to keep track of the last request,
+if it is null there is no more data to return.
 
 **Success Response:**
 
@@ -107,7 +109,10 @@ Retrieves all deliveries registered in the system of a deliveryman by a period o
 {
     success: true,
     message: "The deliveries was successfuly retrieved",
-    data: [delivery Object []]
+    data: {
+        docs: delivery Object[],
+        bookmark: string||null
+    }
 }
 ```
 
@@ -156,7 +161,7 @@ Retrieves a delivery registered in the system by its id.
 ## Getting started
 
 ```
-- cp .env-example .env
+- cp env-example .env
 - open .env file and fill in the required environment variables
 - npm install
 - npm start

--- a/api/lib/DBClient.js
+++ b/api/lib/DBClient.js
@@ -1,0 +1,97 @@
+const Cloudant = require('@cloudant/cloudant');
+
+const user = process.env.CLOUDANT_USER;
+const pw = process.env.CLOUDANT_PW;
+
+function DBClient(db) {
+    if (db && typeof db !== 'string')
+        throw new Error("DBClient db parameter must be of type string, " +
+            `${typeof db} received.`);
+    this._db = db || null;
+    this._client = Cloudant({
+        account: user, password: pw,
+        maxAttempt: 20, plugins:
+            { retry: { retryErrors: true, retryStatusCodes: [429] } }
+    });
+}
+
+DBClient.prototype.getById = function (id, options) {
+    if (typeof id !== 'string')
+        throw new Error(errorMessages.TYPE_MISMATCH_ERROR('id', 'string', typeof id));
+    validateDB(this, options)
+    const db = this._db || options.db;
+    return new Promise((res, rej) => {
+        const database = this._client.db.use(db);
+        database.get(id, function (err, body) {
+            if (err) return rej(err);
+            return res(body);
+        });
+    });
+}
+
+DBClient.prototype.search = function (obj, options) {
+    if (!obj || typeof obj !== 'object')
+        throw new Error("Search function parameter must be a valid object " +
+            `${typeof obj} received.`);
+    if (typeof obj.selector !== 'object')
+        throw new Error("selector_param must be a valid object, " +
+            `${typeof obj.selector} received.`);
+    if (!obj.fields || obj.fields && !Array.isArray(obj.fields))
+        obj.fields = [];
+    validateDB(this, options)
+    const db = this._db || options.db;
+    return new Promise((res, rej) => {
+        let database = this._client.db.use(db);
+        let bookmarkVal = obj.bookmark || null;
+        let limitVal = 100;
+        database.find({
+            selector:
+                obj.selector,
+            fields:
+                obj.fields,
+            limit: limitVal, // max limit is 200,
+            execution_stats: true,
+            bookmark: bookmarkVal
+        }, (err, result) => {
+            if (err) return rej(err);
+            if (result.docs.length <= 0) return res({ docs: [], bookmark: null });
+            if (result.execution_stats.results_returned === limitVal) return res({ docs: result.docs, bookmark: result.bookmark });
+            return res({ docs: result.docs, bookmark: null })
+        })
+    })
+}
+
+DBClient.prototype.insert = function (doc, options) {
+    if (!doc || typeof doc !== 'object')
+        throw new Error(`'doc' parameter must be a valid object ` +
+            `${typeof doc} received.`);
+    validateDB(this, options)
+    const db = this._db || options.db;
+    return new Promise((res, rej) => {
+        const database = this._client.db.use(db);
+        database.insert(doc, (err, body, header) => {
+            if (err) return rej(err);
+            if (body.ok) {
+                doc._id = body.id;
+                doc._rev = body.rev;
+                return res(doc);
+            } else return rej(body);
+        });
+    });
+}
+
+DBClient.prototype.update = function (doc, options) {
+    return this.insert(doc, options);
+}
+
+module.exports = DBClient;
+
+function validateDB(instance, options) {
+    if (!instance._db) {
+        if (!(options && options.db))
+            throw new Error('This client has no default databaset set, and one was not provided.');
+        if (typeof options.db !== 'string')
+            throw new Error(`Wrong type for parameter 'db'. Received ` + typeof options.db
+                + `, expected 'string`);
+    }
+}

--- a/api/lib/ErrorMessages.js
+++ b/api/lib/ErrorMessages.js
@@ -1,0 +1,26 @@
+module.exports.TYPE_MISMATCH_ERROR = function(parameter, expected, received) {
+    return `Wrong type for parameter ${parameter}. Received ${received}, expected ${expected}`;
+}
+
+module.exports.MISSING_FIELD_ERROR = function(field) {
+    return `Missing field "${field}"`;
+}
+
+module.exports.DB_CONNECT_ERROR = () => 'Error connecting to the database, check logs for details.';
+
+module.exports.NO_DB_ERROR = () => 'This client has no default databaset set, and one was not provided.';
+
+module.exports.DB_DOC_NOT_FOUND = function(id) {
+    return `The requested document '${id}' does not exist in the database`;
+}
+
+module.exports.DB_DOC_DATA_CONFLICT = () => 'Data already on the database.';
+
+module.exports.DB_DOC_INVALID_REV = function(id) {
+    return `Wrong 'rev' parameter for '${id}'.`;
+}
+
+module.exports.DATA_NOT_FOUND = () => 'Data not found.';
+
+module.exports.INTERNAL_SERVER_ERROR = () => 'The server encountered an error and could not complete ' +
+                                              'your request. Please try again later.';

--- a/api/lib/HTTPstatusCodes.js
+++ b/api/lib/HTTPstatusCodes.js
@@ -1,0 +1,11 @@
+module.exports.OK = 200;
+module.exports.OK_CREATED = 201;
+module.exports.OK_NO_CONTENT = 204;
+
+module.exports.BAD_REQUEST = 400;
+module.exports.UNAUTHORIZED = 401;
+module.exports.FORBIDDEN = 403;
+module.exports.NOT_FOUND = 404;
+module.exports.CONFLICT = 409;
+
+module.exports.INTERNAL_SERVER_ERROR = 500;


### PR DESCRIPTION
This PR implements the basic libs for our API routes:

- DBClient: Used to CRUD our Cloudant service.
- ErrorMessages: Used for common error messages, such as Internal Server Error.
- HTTPStatusCodes: Used for http status codes our responses.

Signed-of-by: Gustavo Porto Guedes <gustavo.guedes@fatec.sp.gov.br>