### PR TITLE
Add deliveries - getByID endpoint and error handler

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,7 +1,18 @@
 const routes = require('express').Router();
 const v1 = require('./v1');
 
+const HTTPstatusCodes = require('./lib/HTTPstatusCodes');
+const ErrorMessages = require('./lib/ErrorMessages');
+
 routes.use('/v1', v1);
 // Later on we may have other API versions, that will be added here.
+
+// Error Handler for API
+routes.use(function (err, req, res, next) {
+    return res.status(err.status || HTTPstatusCodes.INTERNAL_SERVER_ERROR).json({
+        success: false,
+        message: err.message
+    });
+});
 
 module.exports = routes;

--- a/api/v1/deliveries/getById.js
+++ b/api/v1/deliveries/getById.js
@@ -1,3 +1,26 @@
-module.exports = (req, res) => {
-    res.send('GetById endpoint');
-}
+const DBClient = require('../../lib/DBClient');
+const HTTPstatusCodes = require('../../lib/HTTPstatusCodes');
+const ErrorMessages = require('../../lib/ErrorMessages');
+
+const dbInstance = new DBClient('deliveries');
+
+module.exports = (req, res, next) => {
+    dbInstance.getById(req.params.id)
+        .then((resp) => {
+            res.status(HTTPstatusCodes.OK).json({
+                    success: true,
+                    message: "The delivery was successfuly retrieved.",
+                    data: resp
+                })
+        })
+        .catch((err) => {
+            console.log(err.message);
+            if (err.message === 'missing') {
+                err = new Error(ErrorMessages.DB_DOC_NOT_FOUND(req.params.id));
+                err.status = HTTPstatusCodes.NOT_FOUND;
+            } else {
+                err = new Error(ErrorMessages.INTERNAL_SERVER_ERROR());
+            }
+            return next(err)
+        })
+};


### PR DESCRIPTION
This PR contains:

- Basic error handler for our API
- Logic for getById route. In order to test it out, you can use curl. ```curl -i "http://localhost:3004/api/v1/deliveries/test```

Signed-of-by: Gustavo Porto Guedes <gustavo.guedes@fatec.sp.gov.br>