### PR TITLE
Add basic authentication to our API

### DIFF
--- a/auth/basic.js
+++ b/auth/basic.js
@@ -1,0 +1,35 @@
+const passport = require('passport'),
+    BasicStrategy = require('passport-http').BasicStrategy,
+    crypto = require('crypto');
+
+const DBClient = require('../api/lib/DBClient');
+const dbInstance = new DBClient('admins');
+
+function BasicAuth () {}
+
+passport.use(new BasicStrategy(
+    (username, password, done) => {
+        password = crypto.createHash('md5').update(password).digest('hex');
+        dbInstance.search({
+            selector: {
+                user: username
+            }
+        })
+            .then((resp) => {
+                if (resp.docs.length === 1) {
+                    if (resp.docs[0].password !== password) return done(null, false);
+                    return done(null, true);
+                }
+                return done(null, false);
+            })
+            .catch((err) => {
+                return done(err);
+            })
+    }
+));
+
+BasicAuth.prototype.basic = function () {
+    return passport.authenticate('basic', { session: false });
+}
+
+module.exports = BasicAuth;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1643,6 +1643,28 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
+    "passport": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.0.tgz",
+      "integrity": "sha1-xQlWkTR71a07XhgCOMORTRbwWBE=",
+      "requires": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1"
+      }
+    },
+    "passport-http": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/passport-http/-/passport-http-0.3.0.tgz",
+      "integrity": "sha1-juU9Q4C+nGDfIVGSUCmCb3cRVgM=",
+      "requires": {
+        "passport-strategy": "1.x.x"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1665,6 +1687,11 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "performance-now": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "body-parser": "^1.18.3",
     "dotenv": "^6.2.0",
     "express": "^4.16.4",
-    "morgan": "^1.9.1"
+    "morgan": "^1.9.1",
+    "passport": "^0.4.0",
+    "passport-http": "^0.3.0"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.2",

--- a/server.js
+++ b/server.js
@@ -3,14 +3,17 @@ const express = require('express'),
     api = require('./api'),
     bodyParser = require('body-parser'),
     morgan = require('morgan');
-    
+
+const BasicAuth = require('./auth/basic'),
+      basicAuthInstance = new BasicAuth();
+
 const app = express();
 app.use(morgan('dev'));
 app.use(bodyParser.urlencoded({ extended: false }))
 app.use(bodyParser.json())
 
 // Configuring API routes
-app.use('/api', api);
+app.use('/api', basicAuthInstance.basic(), api);
 
 app.listen(process.env.PORT, () => 
     console.log(`Server listening at port ${process.env.PORT}`)


### PR DESCRIPTION
This PR implements a middleware for our API to
authenticate users, using passport.js basic strategy.

Signed-of-by: Gustavo Porto Guedes <gportog@br.ibm.com>