### PR TITLE
Add unit tests to ErrorMessages.js 

### DIFF
--- a/spec/DBClientSpec.js
+++ b/spec/DBClientSpec.js
@@ -181,7 +181,7 @@ describe('DBClient tests setup', () => {
             })
             expect(deliveryEntries.docs.length).toBeGreaterThanOrEqual(1);
         }, jasmineTimeout)
-        it('should have a defined deliveryEntry bookmark when passed an object and a valid db', async () => {
+        it('should have a string deliveryEntry bookmark when passed an object and a valid db', async () => {
             let date = new Date();
             let deliveryEntry = {
                 deliveryman: 'test@email.com',
@@ -197,15 +197,11 @@ describe('DBClient tests setup', () => {
             }
             let deliveryEntries = await this.dbInstance.search({
                 selector: {
-                    deliveryman: 'test@email.com',
-                    date: {
-                        $gte: `${this.date.getFullYear()}-${this.date.getMonth() + 1}-${this.date.getDate()}`,
-                        $lte: `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
-                    }
+                    deliveryman: 'test@email.com'
                 }
             })
             expect(deliveryEntries.docs.length).toBeGreaterThanOrEqual(100);
-            expect(deliveryEntries.bookmark).toBeDefined();
+            expect(typeof deliveryEntries.bookmark).toBe('string');
         }, jasmineTimeout * 5);
         it('should have an empty deliveryEntries object-array when passed an incorrect date range and a valid db', async () => {
             let date = new Date();

--- a/spec/ErrorMessagesSpec.js
+++ b/spec/ErrorMessagesSpec.js
@@ -1,0 +1,68 @@
+const jasmine = require('jasmine');
+
+const ErrorMessages = require('../api/lib/ErrorMessages');
+
+describe('ErrorMessages tests', () => {
+    it(
+        'TYPE_MISMATCH_ERROR should be equal' +
+        'Wrong type for parameter test. Received number, expected string',
+        () => {
+            expect(ErrorMessages.TYPE_MISMATCH_ERROR('test', 'string', typeof 0))
+                .toEqual('Wrong type for parameter test. Received number, expected string');
+        })
+    it(
+        'VALUE_MISMATCH_ERROR should be equal' +
+        'Wrong value for parameter date_from. Received more than date_to, expected less than date_to',
+        () => {
+            expect(ErrorMessages.VALUE_MISMATCH_ERROR('date_from', 'less than date_to', 'more than date_to'))
+                .toEqual('Wrong value for parameter date_from. Received more than date_to, expected less than date_to');
+        })
+    it(
+        'MISSING_FIELD_ERROR should be equal Missing field "test"',
+        () => {
+            expect(ErrorMessages.MISSING_FIELD_ERROR('test')).toEqual('Missing field "test"');
+        })
+    it(
+        'DB_CONNECT_ERROR should be equal Error connecting to the database, check logs for details.',
+        () => {
+            expect(ErrorMessages.DB_CONNECT_ERROR())
+                .toEqual('Error connecting to the database, check logs for details.');
+        })
+    it(
+        'NO_DB_ERROR should be equal This client has no default databaset set, and one was not provided.',
+        () => {
+            expect(ErrorMessages.NO_DB_ERROR())
+                .toEqual('This client has no default databaset set, and one was not provided.');
+        })
+    it(
+        `DB_DOC_NOT_FOUND should be equal The requested document 'test' does not exist in the database`,
+        () => {
+            expect(ErrorMessages.DB_DOC_NOT_FOUND('test'))
+                .toEqual(`The requested document 'test' does not exist in the database`);
+        })
+    it(
+        'DB_DOC_DATA_CONFLICT should be equal Data already on the database.',
+        () => {
+            expect(ErrorMessages.DB_DOC_DATA_CONFLICT())
+                .toEqual('Data already on the database.');
+        })
+    it(
+        `DB_DOC_INVALID_REV should be equal Wrong 'rev' parameter for 'test'.`,
+        () => {
+            expect(ErrorMessages.DB_DOC_INVALID_REV('test'))
+                .toEqual(`Wrong 'rev' parameter for 'test'.`);
+        })
+    it(
+        'DATA_NOT_FOUND should be equal Data not found.',
+        () => {
+            expect(ErrorMessages.DATA_NOT_FOUND())
+                .toEqual('Data not found.');
+        })
+    it(
+        'INTERNAL_SERVER_ERROR should be equal' +
+        'The server encountered an error and could not complete your request. Please try again later.',
+        () => {
+            expect(ErrorMessages.INTERNAL_SERVER_ERROR())
+                .toEqual('The server encountered an error and could not complete your request. Please try again later.');
+        })
+})


### PR DESCRIPTION
This commit implements the unit testing for our ErrorMessages
lib, in order to avoid any unwanted changes in this lib.

Signed-of-by: Gustavo Porto Guedes <gustavo.guedes@fatec.sp.gov.br>